### PR TITLE
Reduce probability of temp file permission errors

### DIFF
--- a/DwmLutGUI/DwmLutGUI/Injector.cs
+++ b/DwmLutGUI/DwmLutGUI/Injector.cs
@@ -20,7 +20,7 @@ namespace DwmLutGUI
 
         static Injector()
         {
-            var basePath = Environment.ExpandEnvironmentVariables("%SYSTEMROOT%\\Temp\\");
+            var basePath = Path.GetTempPath();
             DllName = "dwm_lut.dll";
             DllPath = basePath + DllName;
             LutsPath = basePath + "luts\\";

--- a/DwmLutGUI/DwmLutGUI/Injector.cs
+++ b/DwmLutGUI/DwmLutGUI/Injector.cs
@@ -20,7 +20,7 @@ namespace DwmLutGUI
 
         static Injector()
         {
-            var basePath = Path.GetTempPath();
+            var basePath = Path.GetTempPath() + Path.DirectorySeparatorChar;
             DllName = "dwm_lut.dll";
             DllPath = basePath + DllName;
             LutsPath = basePath + "luts\\";


### PR DESCRIPTION
Even though the app runs as Administrator, I believe Windows can still restrict access to the system's temp directory. I've seen multiple reports around temp file access being denied, so this should help avoid those cases.