### PR TITLE
Fix profile clearing #42 and debug popups #37

### DIFF
--- a/DwmLutGUI/DwmLutGUI/MainViewModel.cs
+++ b/DwmLutGUI/DwmLutGUI/MainViewModel.cs
@@ -83,6 +83,9 @@ namespace DwmLutGUI
 
         private void SaveConfig()
         {
+            if (_allMonitors.Count == 0)
+                return;
+
             var xElem = new XElement("monitors",
                 new XAttribute("lut_toggle", _toggleKey),
                 _allMonitors.Select(x =>

--- a/lutdwm/dllmain.cpp
+++ b/lutdwm/dllmain.cpp
@@ -24,7 +24,11 @@
 #define RESIZE(x, y) realloc(x, (y) * sizeof(*x));
 #define LOG_FILE_PATH R"(C:\DWMLOG\dwm.log)"
 #define MAX_LOG_FILE_SIZE 20 * 1024 * 1024
+#ifdef _DEBUG
 #define DEBUG_MODE true
+#else
+#define DEBUG_MODE false
+#endif
 
 #if DEBUG_MODE == true
 #define __LOG_ONLY_ONCE(x, y) if (static bool first_log_##y = true) { log_to_file(x); first_log_##y = false; }


### PR DESCRIPTION
Debug popups should no longer show if compiling DLL in release mode. Profiles should no longer clear on toggling HDR in Win11.