### PR TITLE
Fix crash when a configured monitor is not connected

### DIFF
--- a/DwmLutGUI/DwmLutGUI/MainViewModel.cs
+++ b/DwmLutGUI/DwmLutGUI/MainViewModel.cs
@@ -229,11 +229,9 @@ namespace DwmLutGUI
 
                     var sdrLutPaths = monitor.Element("sdr_luts")?.Elements("sdr_lut").Select(x => (string)x).ToList();
                     var hdrLutPaths = monitor.Element("hdr_luts")?.Elements("hdr_lut").Select(x => (string)x).ToList();
-                    var newMonitorData = new MonitorData(path, sdrLutPath, hdrLutPath)
-                    {
-                        SdrLuts = new ObservableCollection<string>(sdrLutPaths),
-                        HdrLuts = new ObservableCollection<string>(hdrLutPaths)
-                    };
+                    var newMonitorData = new MonitorData(path, sdrLutPath, hdrLutPath);
+                    if (sdrLutPaths != null) newMonitorData.SdrLuts = new ObservableCollection<string>(sdrLutPaths);
+                    if (hdrLutPaths != null) newMonitorData.HdrLuts = new ObservableCollection<string>(hdrLutPaths);
                     _allMonitors.Add(newMonitorData);
                 }
             }


### PR DESCRIPTION
If some monitor exists in `config.xml`, but is not connected to the computer when the app launches, the program's control flow will reach [MainViewModel.cs#L232](https://github.com/lauralex/dwm_lut/blob/master/DwmLutGUI/DwmLutGUI/MainViewModel.cs#L232), where the program tries to set `newMonitorData.HdrLuts = new ObservableCollection<string>(hdrLutPaths)`.

However, since `<hdr_luts />` may not be present in `config.xml`, `hdrLutPaths` may be `null`. This will result in a `System.ArgumentNullException` being thrown during construction of the `ObservableCollection<string>`.

This patch fixes the crash by only setting `newMonitorData.HdrLuts` when the corresponding `hdrLutPaths` is not `null`.